### PR TITLE
Windows/MinGW support: define uint (POSIX typedef missing)

### DIFF
--- a/cipher/utils.h
+++ b/cipher/utils.h
@@ -6,6 +6,12 @@
 #include <vector>
 #include <string>
 
+// `uint` is a POSIX/glibc typedef (via <sys/types.h>); MinGW-w64 provides
+// `u_int` but not `uint`, so define it on Windows.
+#ifdef _WIN32
+typedef unsigned int uint;
+#endif
+
 using namespace std;
 using namespace emp;
 using std::string;


### PR DESCRIPTION
MinGW-w64 lacks the POSIX `uint` typedef; define it under `_WIN32` in cipher/utils.h.

Branch = current main + this one commit (merge already reconciled). Needed by primus-labs/pado-core windows-build (primus-zk.dll for zktls-core-sdk). Verified: full Windows chain builds and real attestation (proxytls + mpctls) passes e2e on Windows 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)